### PR TITLE
restore oval scan

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -55,9 +55,8 @@ RUN service mysqld start & \
     sleep 10s &&\
     echo "CREATE USER 'admin'@'localhost' IDENTIFIED BY 'changeme'; GRANT ALL PRIVILEGES ON *.* TO admin@'%' WITH GRANT OPTION; FLUSH PRIVILEGES; SET PASSWORD FOR admin@'%'=PASSWORD('changeme');" | mysql
 
-# Commenting out because of '/bin/sh: /oval/remediate-oscap.sh: No such file or directory' issue which @jumanjiman will t/s
-# RUN /oval/remediate-oscap.sh
-# RUN /oval/vulnerability-scan.sh
+RUN /oval/remediate-oscap.sh
+RUN /oval/vulnerability-scan.sh
 
 ADD /src/files/supervisord.conf /etc/
 CMD ["supervisord", "-n"]


### PR DESCRIPTION
The upstream base image jumanjiman/puppetagent had a regression
that removed the oval scripts. The base image has been fixed.

Resolves ISEexchange/tacstack#10
