### PR TITLE
Hardcode alpine to 3.1

### DIFF
--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -1,4 +1,4 @@
-FROM gliderlabs/alpine:latest
+FROM gliderlabs/alpine:3.1
 
 # Please list packages, one per line, in alpha order.
 RUN apk-install \

--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -39,7 +39,7 @@ RUN apk-install \
     ;
 
 RUN pip install "pip>=1.4,<1.5" --upgrade
-RUN pip install MySQL-python robotframework lxml python-etcd gitpython
+RUN pip install MySQL-python robotframework lxml python-etcd gitpython pylint
 
 # Configure sshd.
 RUN ssh-keygen -q -N "" -t dsa -f /etc/ssh/ssh_host_dsa_key && ssh-keygen -q -N "" -t rsa -f /etc/ssh/ssh_host_rsa_key 

--- a/appdata/Dockerfile
+++ b/appdata/Dockerfile
@@ -1,4 +1,4 @@
-FROM gliderlabs/alpine:latest
+FROM gliderlabs/alpine:3.1
 
 RUN apk-install mysql mysql-client
 

--- a/circle.yml
+++ b/circle.yml
@@ -7,7 +7,9 @@ dependencies:
   override:
     - docker info
     - docker images
-    - script/build
+    - docker build -t tacstack     app/
+    - docker build -t mysqldatavol appdata/
+    - docker build -t ftpdatavol   ftpdata/
     - docker images
 
 test:

--- a/ftpdata/Dockerfile
+++ b/ftpdata/Dockerfile
@@ -1,4 +1,4 @@
-FROM gliderlabs/alpine:latest
+FROM gliderlabs/alpine:3.1
 
 VOLUME /var/ftp/pub/uploads
 CMD /bin/sh


### PR DESCRIPTION
Temporary change to get around package dependency issue that exists with Alpine v3.2:
```
user@devenv:~/tacstack(add_circleci_build*)$ docker build --no-cache -t tacstack     app/
Sending build context to Docker daemon 46.59 kB
Sending build context to Docker daemon 
Step 0 : FROM gliderlabs/alpine:latest
 ---> 3adc3de69ee5
Step 1 : RUN apk upgrade --update &&     apk-install     alpine-sdk     apache2     bash     bash-completion     libffi     libffi-dev     libxml2     libxml2-dev     libxslt     libxslt-dev     mysql-dev     mysql     mysql-client     openssh     openssh-client     php     php-dev     php-gd     php-memcache     phpmyadmin     php-mysql     php-pspell     php-snmp     php-xml     php-xmlrpc     py-libxml2     py-libxslt     py-nose     py-pip     python     python-dev     subversion     supervisor     vim     ;
 ---> Running in a73759e3c115
fetch http://dl-4.alpinelinux.org/alpine/v3.2/main/x86_64/APKINDEX.tar.gz
OK: 6 MiB in 15 packages
fetch http://dl-4.alpinelinux.org/alpine/v3.2/main/x86_64/APKINDEX.tar.gz
ERROR: unsatisfiable constraints:
  mysql-dev (missing):
    required by: world[mysql-dev]
INFO[0002] The command [/bin/sh -c apk upgrade --update &&     apk-install     alpine-sdk     apache2     bash     bash-completion     libffi     libffi-dev     libxml2     libxml2-dev     libxslt     libxslt-dev     mysql-dev     mysql     mysql-client     openssh     openssh-client     php     php-dev     php-gd     php-memcache     phpmyadmin     php-mysql     php-pspell     php-snmp     php-xml     php-xmlrpc     py-libxml2     py-libxslt     py-nose     py-pip     python     python-dev     subversion     supervisor     vim     ;] returned a non-zero code: 1 
```