### PR TITLE
upgrade to alpine 3.2 and use official image

### DIFF
--- a/MAP_Setup_README.md
+++ b/MAP_Setup_README.md
@@ -8,11 +8,11 @@ Import FTP Data
 
 If there is an existing FTP data volume export its contents using the command below. Change the `--volumes-from` argument and the name of the resulting tar file:
 
-    docker run --rm --volumes-from ftpdatavolprod_old -v $(pwd):/backup gliderlabs/alpine:latest tar cvf /backup/ftpdata_2015_03_29.tar /var/ftp/pub/uploads/
+    docker run --rm --volumes-from ftpdatavolprod_old -v $(pwd):/backup alpine:latest tar cvf /backup/ftpdata_2015_03_29.tar /var/ftp/pub/uploads/
 
 Now import the tar ball into your just-created container using the command below. Change the `--volumes-from` argument and the name of the tar file:
 
-    docker run --rm -it --volumes-from ftpdatavolprod_new -v $(pwd):/backup gliderlabs/alpine:latest tar xvf /backup/ftpdata_2015_03_29.tar
+    docker run --rm -it --volumes-from ftpdatavolprod_new -v $(pwd):/backup alpine:latest tar xvf /backup/ftpdata_2015_03_29.tar
 
 Import MySQL Data
 -------------

--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -1,7 +1,7 @@
-FROM gliderlabs/alpine:3.1
+FROM alpine:3.2
 
 # Please list packages, one per line, in alpha order.
-RUN apk-install \
+RUN apk add --update \
     alpine-sdk \
     apache2 \
     bash \
@@ -12,9 +12,7 @@ RUN apk-install \
     libxml2-dev \
     libxslt \
     libxslt-dev \
-    mysql \
-    mysql-client \
-    mysql-dev \
+    mariadb-dev \
     openssh \
     openssh-client \
     php \
@@ -36,7 +34,7 @@ RUN apk-install \
     subversion \
     supervisor \
     vim \
-    ;
+    && rm -f /var/cache/apk/*
 
 RUN pip install "pip>=1.4,<1.5" --upgrade
 RUN pip install MySQL-python robotframework lxml python-etcd gitpython pylint

--- a/app/src/root/install_mysql.sh
+++ b/app/src/root/install_mysql.sh
@@ -5,7 +5,7 @@ set -e
 
 # The setup step requires /run/openrc/softlevel,
 # which we copy in via the Dockerfile.
-/etc/init.d/mysql setup
+/etc/init.d/mariadb setup
 
 sock_path="/var/lib/mysql/mysql.sock"
 

--- a/appdata/Dockerfile
+++ b/appdata/Dockerfile
@@ -1,6 +1,9 @@
-FROM gliderlabs/alpine:3.1
+FROM alpine:3.2
 
-RUN apk-install mysql mysql-client
+RUN apk add --update \
+      mariadb \
+      mariadb-client \
+    && rm -f /var/cache/apk/*
 
 COPY src /
 RUN /root/install_mysql.sh

--- a/appdata/src/root/install_mysql.sh
+++ b/appdata/src/root/install_mysql.sh
@@ -5,7 +5,7 @@ set -e
 
 # The setup step requires /run/openrc/softlevel,
 # which we copy in via the Dockerfile.
-/etc/init.d/mysql setup
+/etc/init.d/mariadb setup
 
 sock_path="/var/lib/mysql/mysql.sock"
 

--- a/ftpdata/Dockerfile
+++ b/ftpdata/Dockerfile
@@ -1,4 +1,4 @@
-FROM gliderlabs/alpine:3.1
+FROM alpine:3.2
 
 VOLUME /var/ftp/pub/uploads
 CMD /bin/sh


### PR DESCRIPTION
* gliderlabs/alpine has become the official alpine image,
  albeit without the `apk-install` wrapper.
  http://gliderlabs.com/blog/2015/03/20/our-minimal-alpine-linux-image-joins-docker-official-images/

* mariadb-dev replaces mysql-dev and pulls in mysql as deps
  http://bugs.alpinelinux.org/issues/4264

This is a permanent fix to replace the temp fix from
https://github.com/ISEexchange/tacstack/pull/60
(commit 96766b74bc805e95e677e07fd9b88473b1bd537a).

cc @cbautista1002 