### PR TITLE
Update setup script

### DIFF
--- a/app/src/home/bdt_map_testenv_setup.py
+++ b/app/src/home/bdt_map_testenv_setup.py
@@ -222,7 +222,7 @@ if __name__ == "__main__":
 
     # 3a. Pull and go into develop branch
 
-    print 'Would you like to checkout upstream\'s develop branch? y|n'
+    print '\nWould you like to checkout upstream\'s develop branch? y|n'
     line = sys.stdin.readline()
     if line.rstrip('\n') == 'y':
 
@@ -245,6 +245,14 @@ if __name__ == "__main__":
 
     os.chdir('/home')
     clone_repo('robotframework', conn_type)
+
+    os.chdir('/home')
+    print '\nCloning glowing-configurator repo...'
+    subprocess.Popen(['git clone git@github.com:cbautista1002/glowing-configurator.git'], shell=True,
+            stdout=subprocess.PIPE).communicate()
+    subprocess.Popen(['echo "source /home/glowing-configurator/.bashrc" >> ~/.bashrc'], shell=True,
+            stdout=subprocess.PIPE).communicate()
+    print "\nRun 'source  ~/.bashrc' to load new aliases from glowing-configurator"
 
     # 4. Import map_db
     import_map_db()

--- a/app/src/home/bdt_map_testenv_setup.py
+++ b/app/src/home/bdt_map_testenv_setup.py
@@ -173,7 +173,7 @@ def update_httpd_settings():
             'DocumentRoot "/var/www/localhost/htdocs/map"'),
 
 
-def process_control():
+def process_control(add_nodejs):
     server_url = 'http://localhost:9001/RPC2'
     try:
         server = xmlrpclib.Server(server_url)
@@ -204,13 +204,14 @@ def process_control():
         print 'Exception: %s' % e
         return False
 
-    print 'Starting nodejs with supervisor'
-    try:
-        server.supervisor.startProcess('nodejs')
-    except Exception, e:
-        print 'Failed to start nodejs'
-        print 'Exception: %s' % e
-        return False
+    if add_nodejs == 'y':
+        print 'Starting nodejs with supervisor'
+        try:
+            server.supervisor.startProcess('nodejs')
+        except Exception, e:
+            print 'Failed to start nodejs'
+            print 'Exception: %s' % e
+            return False
 
 
 
@@ -258,7 +259,8 @@ if __name__ == "__main__":
     # 3b. Install npm packages
     print '\nWould you like to install NodeJS\' npm packages? y|n'
     line = sys.stdin.readline()
-    if line.rstrip('\n') == 'y':
+    add_nodejs = line.rstrip('\n')
+    if add_nodejs == 'y':
         os.chdir('/home/bdt/map/src/map_nodejs_server')
         r = subprocess.Popen(['npm install'], shell=True,
             stdout=subprocess.PIPE).communicate()
@@ -286,7 +288,7 @@ if __name__ == "__main__":
     update_httpd_settings()
 
     # 7. Restart/start supervisor processes
-    process_control()
+    process_control(add_nodejs)
 
     print "\nYou're all set!\n"
 

--- a/app/src/root/.bashrc
+++ b/app/src/root/.bashrc
@@ -2,13 +2,6 @@
 alias vbrc='vi ~/.bashrc'
 alias vi='vim'
 
-# svn aliases
-alias svs='svn status'
-alias svd='svn diff'
-alias svc='svn commit '
-alias svu='svn update'
-alias sva='svn add'
-
 # Find file aliases
 alias fip='find . -name \*.py | xargs grep -i'
 alias fia='find . -name \* | xargs grep -i'
@@ -21,3 +14,16 @@ alias psf='ps -ef | grep -i '
 alias g='grep'
 alias gi='grep -i'
 alias sbrc='source ~/.bashrc'
+
+# Aliases for controlling MAP
+alias stopmap='supervisorctl stop map'
+alias startmap='supervisorctl start map'
+alias restartmap='supervisorctl restart map'
+alias rml='rm -fv /var/log/MAPServer.log'
+alias tml='tail -f /var/log/MAPServer.log'
+alias cleanmap="stopmap; rml; echo 'use map_db; DELETE FROM task_queue; UPDATE template_instance SET status=2; UPDATE template SET template_status=2' | mysql"
+alias launchmap='startmap; tml'
+
+export TERM=xterm
+cd /home
+


### PR DESCRIPTION
Fixed all issues with setup script. Add ability to checkout develop branch. Added option to start up nodejs.

I successfully ran it in a fresh container:
```
user@devenv:~/tacstack(update_setup_script*)$ de newcarlos_mapapptestenv_1 bash
bash-4.3# 
bash-4.3# 
bash-4.3# 
bash-4.3# python bdt_map_testenv_setup.py 
Would you like to import your SSH keys for Github communication? y|n
y

Let's import your ssh keys to make talking to Github easier
Enter private key for ssh'ing to Github
<redacted>
Successfully captured private key

Enter matching public key
<redacted>
Successfully captured public key

Writing private key to /root/.ssh/id_rsa

Changed permissions for /root/.ssh/id_rsa to 0600
Saved private key into /root/.ssh/id_rsa. Set permission to 0600

Writing public key to /root/.ssh/id_rsa.pub

Changed permissions for /root/.ssh/id_rsa.pub to 0644
Saved public key into /root/.ssh/id_rsa.pub. Set permission to 0644

Changed permissions for /root/.ssh/config to 0600

Whats the SSH clone URL for your forked bdt repo?
git@github.com:cbautista1002/bdt.git
Successfully cloned git@github.com:cbautista1002/bdt.git into /home/bdt
Successfully added upstream repo git@github.com:ISEexchange/bdt.git

What email address should we use for your git config?
<redacted>

What full name should we use for your git config?
Carlos Bautista

Would you like to git pull upstream's develop branch? y|n
y
Switched to a new branch 'develop'

None
Warning: Permanently added 'github.com,192.30.252.130' (RSA) to the list of known hosts.
From github.com:cbautista1002/bdt
 * branch            add_nodejs -> FETCH_HEAD
Auto-merging map/src/map_frontend_web_gui/ise/php/shared.php
Merge made by the 'recursive' strategy.
 circle.yml                                         |  36 ++
 <redacted>
 create mode 100644 pylintrc

None

Would you like to install NodeJS' npm packages? y|n
y
npm WARN package.json map_nodejs_server@1.0.0 No description
npm WARN package.json map_nodejs_server@1.0.0 No repository field.
npm WARN package.json map_nodejs_server@1.0.0 No README data

> utf-8-validate@1.1.0 install /home/bdt/map/src/map_nodejs_server/node_modules/socket.io/node_modules/engine.io/node_modules/ws/node_modules/utf-8-validate
> node-gyp rebuild

make: Entering directory '/home/bdt/map/src/map_nodejs_server/node_modules/socket.io/node_modules/engine.io/node_modules/ws/node_modules/utf-8-validate/build'
  CXX(target) Release/obj.target/validation/src/validation.o
  SOLINK_MODULE(target) Release/obj.target/validation.node
  SOLINK_MODULE(target) Release/obj.target/validation.node: Finished
  COPY Release/validation.node
make: Leaving directory '/home/bdt/map/src/map_nodejs_server/node_modules/socket.io/node_modules/engine.io/node_modules/ws/node_modules/utf-8-validate/build'

> bufferutil@1.1.0 install /home/bdt/map/src/map_nodejs_server/node_modules/socket.io/node_modules/engine.io/node_modules/ws/node_modules/bufferutil
> node-gyp rebuild

make: Entering directory '/home/bdt/map/src/map_nodejs_server/node_modules/socket.io/node_modules/engine.io/node_modules/ws/node_modules/bufferutil/build'
  CXX(target) Release/obj.target/bufferutil/src/bufferutil.o
  SOLINK_MODULE(target) Release/obj.target/bufferutil.node
  SOLINK_MODULE(target) Release/obj.target/bufferutil.node: Finished
  COPY Release/bufferutil.node
make: Leaving directory '/home/bdt/map/src/map_nodejs_server/node_modules/socket.io/node_modules/engine.io/node_modules/ws/node_modules/bufferutil/build'

> utf-8-validate@1.1.0 install /home/bdt/map/src/map_nodejs_server/node_modules/socket.io/node_modules/socket.io-client/node_modules/engine.io-client/node_modules/ws/node_modules/utf-8-validate
> node-gyp rebuild

make: Entering directory '/home/bdt/map/src/map_nodejs_server/node_modules/socket.io/node_modules/socket.io-client/node_modules/engine.io-client/node_modules/ws/node_modules/utf-8-validate/build'
  CXX(target) Release/obj.target/validation/src/validation.o
  SOLINK_MODULE(target) Release/obj.target/validation.node
  SOLINK_MODULE(target) Release/obj.target/validation.node: Finished
  COPY Release/validation.node
make: Leaving directory '/home/bdt/map/src/map_nodejs_server/node_modules/socket.io/node_modules/socket.io-client/node_modules/engine.io-client/node_modules/ws/node_modules/utf-8-validate/build'

> bufferutil@1.1.0 install /home/bdt/map/src/map_nodejs_server/node_modules/socket.io/node_modules/socket.io-client/node_modules/engine.io-client/node_modules/ws/node_modules/bufferutil
> node-gyp rebuild

make: Entering directory '/home/bdt/map/src/map_nodejs_server/node_modules/socket.io/node_modules/socket.io-client/node_modules/engine.io-client/node_modules/ws/node_modules/bufferutil/build'
  CXX(target) Release/obj.target/bufferutil/src/bufferutil.o
  SOLINK_MODULE(target) Release/obj.target/bufferutil.node
  SOLINK_MODULE(target) Release/obj.target/bufferutil.node: Finished
  COPY Release/bufferutil.node
make: Leaving directory '/home/bdt/map/src/map_nodejs_server/node_modules/socket.io/node_modules/socket.io-client/node_modules/engine.io-client/node_modules/ws/node_modules/bufferutil/build'
express@4.13.1 node_modules/express
├── escape-html@1.0.2
├── merge-descriptors@1.0.0
├── array-flatten@1.1.0
├── cookie@0.1.3
├── utils-merge@1.0.0
├── cookie-signature@1.0.6
├── methods@1.1.1
├── fresh@0.3.0
├── range-parser@1.0.2
├── path-to-regexp@0.1.6
├── vary@1.0.1
├── content-type@1.0.1
├── etag@1.7.0
├── parseurl@1.3.0
├── content-disposition@0.5.0
├── serve-static@1.10.0
├── depd@1.0.1
├── qs@4.0.0
├── finalhandler@0.4.0 (unpipe@1.0.0)
├── on-finished@2.3.0 (ee-first@1.1.1)
├── debug@2.2.0 (ms@0.7.1)
├── proxy-addr@1.0.8 (forwarded@0.1.0, ipaddr.js@1.0.1)
├── send@0.13.0 (destroy@1.0.3, ms@0.7.1, statuses@1.2.1, mime@1.3.4, http-errors@1.3.1)
├── type-is@1.6.5 (media-typer@0.3.0, mime-types@2.1.3)
└── accepts@1.2.11 (negotiator@0.5.3, mime-types@2.1.3)

socket.io@1.3.6 node_modules/socket.io
├── debug@2.1.0 (ms@0.6.2)
├── has-binary-data@0.1.3 (isarray@0.0.1)
├── socket.io-adapter@0.3.1 (object-keys@1.0.1, debug@1.0.2, socket.io-parser@2.2.2)
├── socket.io-parser@2.2.4 (isarray@0.0.1, debug@0.7.4, component-emitter@1.1.2, benchmark@1.0.0, json3@3.2.6)
├── engine.io@1.5.2 (base64id@0.1.0, debug@1.0.3, engine.io-parser@1.2.1, ws@0.7.2)
└── socket.io-client@1.3.6 (to-array@0.1.3, indexof@0.0.1, debug@0.7.4, component-bind@1.0.0, backo2@1.0.2, object-component@0.0.3, component-emitter@1.1.2, has-binary@0.1.6, parseuri@0.0.2, engine.io-client@1.5.2)

None

Whats the SSH clone URL for your forked robotframework repo?
git@github.com:cbautista1002/robotframework-ise.git
Successfully cloned git@github.com:cbautista1002/robotframework-ise.git into /home/robotframework
Successfully added upstream repo git@github.com:ISEexchange/robotframework.git

Cloning glowing-configurator repo...
Cloning into 'glowing-configurator'...
Warning: Permanently added 'github.com,192.30.252.128' (RSA) to the list of known hosts.
remote: Counting objects: 39, done.
remote: Total 39 (delta 0), reused 0 (delta 0), pack-reused 39
Receiving objects: 100% (39/39), done.
Resolving deltas: 100% (10/10), done.
Checking connectivity... done.

Run 'source  ~/.bashrc' to load new aliases from glowing-configurator

Importing map_db database from /home/bdt/map/src/map_database/map_db_ref_data.sql

Creating symlinks for /var/www/localhost/htdocs/map -> /home/bdt/map/src/map_frontend_web_gui/
Creating symlinks for /var/www/localhost/htdocs/map/results -> /var/ftp/pub/uploads
Successfully created symlinks
Creating symlinks for /var/www/localhost/htdocs/map/reports -> /var/ftp/pub/uploads/reports/
Successfully created symlinks

Setting httpd DocumentRoot to /var/www/localhost/htdocs/map

Changed permissions for /etc/phpmyadmin/config.inc.php to 0644

Restarting httpd with supervisor
Starting map with supervisor
Starting nodejs with supervisor

You're all set!

bash-4.3# supervisorctl status
httpd                            RUNNING   pid 499, uptime 0:00:07
map                              RUNNING   pid 505, uptime 0:00:06
mysql                            RUNNING   pid 12, uptime 0:02:08
nodejs                           RUNNING   pid 522, uptime 0:00:04
sshd                             RUNNING   pid 11, uptime 0:02:08
```

Complexity: Low

@isehgu @jwasserzug Please review and merge.