### PR TITLE
Update docker to 1.8.3

### DIFF
--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -45,7 +45,7 @@ RUN apk add --update \
 RUN pip install "pip>=1.4,<1.5" --upgrade
 RUN pip install MySQL-python robotframework lxml python-etcd gitpython pylint socketIO-client
 
-RUN curl https://get.docker.com/builds/Linux/x86_64/docker-1.7.1 > /usr/bin/docker && \
+RUN curl https://get.docker.com/builds/Linux/x86_64/docker-1.8.3 > /usr/bin/docker && \
     chmod +x /usr/bin/docker
 
 # Configure sshd.


### PR DESCRIPTION
Update docker client from 1.7.1 to 1.8.3

@jumanjiman Please :ship:

PS: Not going with 1.10.x because of known issues.

Tested locally:

```
bash-4.3# curl https://get.docker.com/builds/Linux/x86_64/docker-1.8.3 > /usr/bin/docker
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 20.5M  100 20.5M    0     0  3991k      0  0:00:05  0:00:05 --:--:-- 4686k
bash-4.3# chmod +x /usr/bin/docker

bash-4.3# docker version
Client:
 Version:      1.8.3
 API version:  1.20
 Go version:   go1.4.2
 Git commit:   f4bf5c7
 Built:        Mon Oct 12 18:01:15 UTC 2015
 OS/Arch:      linux/amd64

Server:
 Version:      1.10.0
 API version:  1.22
 Go version:   go1.4.3
 Git commit:   e21da33
 Built:
 OS/Arch:      linux/amd64
```
